### PR TITLE
Creacion de objeto y etiqueta

### DIFF
--- a/src/controllers/etiqueta.js
+++ b/src/controllers/etiqueta.js
@@ -22,4 +22,21 @@ export default {
       });
     }
   },
+
+  async findAll(req, res) {
+    const params = req.parsedBody;
+
+    try {
+      const etiquetas = await services.etiqueta.findAll(req.params.nombre);
+
+      res.status(202).json({
+        etiquetas
+      });
+    } catch (err) {
+      console.log(err);
+      res.status(501).json({
+        error: 'No se encontraron etiquetas.'
+      });
+    }
+  },
 };

--- a/src/routes/etiqueta.js
+++ b/src/routes/etiqueta.js
@@ -8,7 +8,7 @@ api.get('/', etiqueta.getAll);
 
 api.post('/', etiqueta.hi);
 
-api.get('/:id', etiqueta.hi);
+api.get('/:nombre', etiqueta.findAll);
 
 api.put('/:id', etiqueta.hi);
 

--- a/src/routes/objetos.js
+++ b/src/routes/objetos.js
@@ -10,7 +10,7 @@ api.post('/', objetos.create);
 
 api.get('/:id', objetos.get);
 
-api.put('/:id', objetos.hi);
+api.put('/', objetos.create);
 
 api.delete('/:id', objetos.hi);
 

--- a/src/services/etiqueta.js
+++ b/src/services/etiqueta.js
@@ -6,4 +6,17 @@ export default {
 
     return etiqueta;
   },
+
+  findAll: async (nombre) => {
+    const Op = Models.Etiqueta.sequelize.Sequelize.Op;
+    const etiqueta = await Models.Etiqueta.findAll({
+      where: {
+        nombre_etiqueta: {
+          [Op.like]: `%${nombre}%`
+        }
+      }
+    });
+
+    return etiqueta;
+  },
 };

--- a/src/services/objetos.js
+++ b/src/services/objetos.js
@@ -3,35 +3,35 @@ import Models from '../models';
 export default {
   create: async (params) => {
     const {
-      nombre,
-      etiquetas
+      tags,
+      newTags,
     } = params;
 
-    if (!nombre) {
-      throw new Error({
-        status: 400,
-        message: 'Bad Request. Missing Fields'
-      });
-    }
-
-    let etiquetasArray = [];
-    etiquetas.forEach(etiqueta => {
-      etiquetasArray.push({
-        'nombre_etiqueta': etiqueta
-      });
-    });
+    // if (!nombre_etiqueta) {
+    //   throw new Error({
+    //     status: 400,
+    //     message: 'Bad Request. Missing Fields'
+    //   });
+    // }
 
     const createParams = {
       ...params,
       'usuario_registro_entrada': 1,
-      'etiquetas': etiquetasArray,
+      'etiquetas': newTags,
     };
+    
+    delete createParams.tags;
+    delete createParams.newTags;
 
     return Models.Objetos.create(createParams, {
       include: [{
         model: Models.Etiqueta,
         as: 'etiquetas'
       }]
+    }).then(objeto => {
+      if ( tags ) {
+        return objeto.addEtiquetas(tags.map(tag => tag.id_etiqueta)).then(res => { return objeto });
+      }
     });
   },
   get: async (objectId) => {


### PR DESCRIPTION
#### What does this PR do?
- Se implementa validacion de etiquetas ya existentes.
    Ahora crea etiquetas nuevas y, para las ya existentes, solo agrega la relacion objetos-etiquetas
- Se agrega funcion para buscar por nombre de etiqueta

#### Where should the reviewer start?
Ruta etiqueta/:nombre para obtener las etiquetas con nombre similar al recibido (like)
En formulario de creacion de objeto, el back espera recibir el array tags para viejas etiquetas, y newTags para nuevas etiquetas del objeto.

#### What are the relevant tickets?
#25 