### PR TITLE
Update de objetos

### DIFF
--- a/src/controllers/objetos.js
+++ b/src/controllers/objetos.js
@@ -86,4 +86,19 @@ export default {
       });
     }
   },
+
+  async update(req, res) {
+    try {
+      const objetos = await services.objetos.update(req.parsedBody);
+
+      res.status(202).json({
+        objetos,
+      });
+    } catch (err) {
+      console.log(err);
+      res.status(501).json({
+        error: 'No fue posible .',
+      });
+    }
+  },
 };

--- a/src/routes/objetos.js
+++ b/src/routes/objetos.js
@@ -18,4 +18,6 @@ api.get('/donate/', objetos.getDonate);
 
 api.post('/donate/', objetos.postDonate);
 
+api.post('/update/', objetos.update);
+
 export default api;


### PR DESCRIPTION
#### What does this PR do?
- Implementa endpoint POST /api/objetos/update que permite actualizar los campos: nombre, tags y subCategoria

#### Where should the reviewer start?
Routes de objetos

#### How should this be manually tested?
POST request /api/objetos/update
{
	"nombre": "foo334",
	"objetoId": 3,
	"tags": [1, 4, 31],
	"newTags": ["newEtiqueta1, "newEtiqueta2"],
	"subcategoria": 13
}

#### What are the relevant tickets?
Closes #55 